### PR TITLE
Fixes All Problems with Early Skip

### DIFF
--- a/Static Files/scripts/1fmEarlySkip.lua
+++ b/Static Files/scripts/1fmEarlySkip.lua
@@ -1,0 +1,26 @@
+LUAGUI_NAME = "1fmEarlySkip"
+LUAGUI_AUTH = "denhonator/TopazTK (edited by deathofall84)"
+LUAGUI_DESC = "Allows skipping cutscenes without waiting for them."
+
+local lastFade = 0
+
+function _OnInit()
+    if GAME_ID == 0xAF71841E and ENGINE_TYPE == "BACKEND" then
+        require("VersionCheck")
+        if canExecute then
+            WriteInt(skipArray1 - 0x04, 0xFF)
+            WriteArray(skipArray1, { 0x0F, 0x9E, 0xC0, 0xC3 })
+
+            WriteInt(skipArray2 - 0x04, 0xFF)
+            WriteArray(skipArray2, { 0x0F, 0x9E, 0xC0, 0xC3 })
+
+            WriteArray(skipArray3, { 0xEB, 0x10 })
+        end
+    else
+        ConsolePrint("KH1 not detected, not running script")
+    end
+end
+
+function _OnFrame()
+end
+

--- a/Static Files/scripts/io_packages/EGSGlobal_1_0_0_10.lua
+++ b/Static Files/scripts/io_packages/EGSGlobal_1_0_0_10.lua
@@ -83,7 +83,8 @@ zantValue = 0
 
 -- early skip
 skipArray1 = 0x1786FC
-skipArray2 = 0x17D543
+skipArray2 = 0x17871C
+skipArray3 = 0x17D543
 skipFlag1 = 0x2340938
 skipFlag2 = 0x2340E20
 

--- a/Static Files/scripts/io_packages/EGSGlobal_1_0_0_8.lua
+++ b/Static Files/scripts/io_packages/EGSGlobal_1_0_0_8.lua
@@ -83,7 +83,8 @@ zantValue = 0
 
 -- early skip
 skipArray1 = 0x17605C
-skipArray2 = 0x17AEA3
+skipArray2 = 0x17607C
+skipArray3 = 0x17AEA3
 skipFlag1 = 0x233C5B8
 skipFlag2 = 0x233CAA0
 

--- a/Static Files/scripts/io_packages/EGSGlobal_1_0_0_9.lua
+++ b/Static Files/scripts/io_packages/EGSGlobal_1_0_0_9.lua
@@ -83,7 +83,8 @@ zantValue = 0
 
 -- early skip
 skipArray1 = 0x1783BC
-skipArray2 = 0x17D203
+skipArray2 = 0x1783FC
+skipArray3 = 0x17D203
 skipFlag1 = 0x23408B8
 skipFlag2 = 0x2340DA0
 

--- a/Static Files/scripts/io_packages/EGSJP_1_0_0_10.lua
+++ b/Static Files/scripts/io_packages/EGSJP_1_0_0_10.lua
@@ -83,7 +83,8 @@ zantValue = 0
 
 -- early skip
 skipArray1 = 0x17853C
-skipArray2 = 0x17D383
+skipArray2 = 0x17855C
+skipArray3 = 0x17D383
 skipFlag1 = 0x2340938
 skipFlag2 = 0x2340E20
 

--- a/Static Files/scripts/io_packages/EGSJP_1_0_0_8.lua
+++ b/Static Files/scripts/io_packages/EGSJP_1_0_0_8.lua
@@ -83,7 +83,8 @@ zantValue = 0
 
 -- early skip
 skipArray1 = 0x17605C
-skipArray2 = 0x17AEA3
+skipArray2 = 0x17607C
+skipArray3 = 0x17AEA3
 skipFlag1 = 0x233C5B8
 skipFlag2 = 0x233CAA0
 

--- a/Static Files/scripts/io_packages/EGSJP_1_0_0_9.lua
+++ b/Static Files/scripts/io_packages/EGSJP_1_0_0_9.lua
@@ -83,7 +83,8 @@ zantValue = 0
 
 -- early skip
 skipArray1 = 0x1781FC
-skipArray2 = 0x17D043
+skipArray2 = 0x17821C
+skipArray3 = 0x17D043
 skipFlag1 = 0x233F8B8
 skipFlag2 = 0x233FDA0
 

--- a/Static Files/scripts/io_packages/SteamGlobal_1_0_0_1.lua
+++ b/Static Files/scripts/io_packages/SteamGlobal_1_0_0_1.lua
@@ -83,7 +83,8 @@ zantValue = 0
 
 -- early skip
 skipArray1 = 0x17A49C
-skipArray2 = 0x17F323
+skipArray2 = 0x17A4BC
+skipArray3 = 0x17F323
 skipFlag1 = 0x233FEE8
 skipFlag2 = 0x23404D0
 

--- a/Static Files/scripts/io_packages/SteamGlobal_1_0_0_2.lua
+++ b/Static Files/scripts/io_packages/SteamGlobal_1_0_0_2.lua
@@ -83,7 +83,8 @@ zantValue = 0
 
 -- early skip
 skipArray1 = 0x17A7DC
-skipArray2 = 0x17F663
+skipArray2 = 0x17A7FC
+skipArray3 = 0x17F663
 skipFlag1 = 0x233FEE8
 skipFlag2 = 0x23404D0
 

--- a/Static Files/scripts/io_packages/SteamJP_1_0_0_1.lua
+++ b/Static Files/scripts/io_packages/SteamJP_1_0_0_1.lua
@@ -83,7 +83,8 @@ zantValue = 0
 
 -- early skip
 skipArray1 = 0x17A21C
-skipArray2 = 0x17F0A3
+skipArray2 = 0x17A23C
+skipArray3 = 0x17F0A3
 skipFlag1 = 0x233FEE8
 skipFlag2 = 0x23404D0
 

--- a/Static Files/scripts/io_packages/SteamJP_1_0_0_2.lua
+++ b/Static Files/scripts/io_packages/SteamJP_1_0_0_2.lua
@@ -83,7 +83,8 @@ zantValue = 0
 
 -- early skip
 skipArray1 = 0x17A55C
-skipArray2 = 0x17F3E3
+skipArray2 = 0x17A57C
+skipArray3 = 0x17F3E3
 skipFlag1 = 0x233FEE8
 skipFlag2 = 0x23404D0
 


### PR DESCRIPTION
- The skip can now happen at maximum fade value and below (0xFF-0x00) so if timed perfectly, one-frame skipping is possible.
- The cutscenes previously broken by fade adjustment (After Hook, Riku HB) are now fixed.
- Should work with every version, cutscenes will not look weird anymore.