### PR TITLE
Add script to communicate map update information

### DIFF
--- a/Static Files/scripts/1fmRandoMapUpdate.lua
+++ b/Static Files/scripts/1fmRandoMapUpdate.lua
@@ -1,0 +1,125 @@
+LUAGUI_NAME = "1fmRandoMapUpdate"
+LUAGUI_AUTH = "culk"
+LUAGUI_DESC = "Kingdom Hearts 1FM Randomizer Update Tracker Map Tab"
+
+-- TODO: test if can use global util functions
+
+local game_version = 1
+
+if os.getenv('LOCALAPPDATA') ~= nil then
+    client_communication_path = os.getenv('LOCALAPPDATA') .. "\\KH1FM\\"
+else
+    client_communication_path = os.getenv('HOME') .. "/KH1FM/"
+    ok, err, code = os.rename(client_communication_path, client_communication_path)
+    if not ok and code ~= 13 then
+        os.execute("mkdir " .. path)
+    end
+end
+
+function file_exists(name)
+   local f=io.open(name,"r")
+   if f~=nil then io.close(f) return true else return false end
+end
+
+function read_world()
+    --[[Gets the numeric value of the currently occupied world]]
+    local world_address = {0x2340E5C, 0x233FE84}
+    return ReadByte(world_address[game_version])
+end
+
+function read_room()
+    --[[Gets the numeric value of the currently occupied room]]
+    local room_address = {0x2340E5C + 0x68, 0x233FE84 + 0x8}
+    return ReadByte(room_address[game_version])
+end
+
+function is_in_gummi_ship()
+    local inGummi = {0x50832D, 0x5075A8}
+    return ReadByte(inGummi[game_version]) ~= 0
+end
+
+function read_gummi_select()
+    local gummiselect = {0x507D7C, 0x50707C}
+    return ReadByte(gummiselect[game_version])
+end
+
+function write_map_update_file(world_id, room_id)
+    map_update_date = os.date("!%Y%m%d%H%M%S")
+    --map_update_file_path = client_communication_path .. "mapupdate" .. "_" .. tostring(map_update_date) .. "_" .. tostring(world_id) .. "_" .. tostring(room_id) .. "_" .. tostring(current_gummi) .. "_" .. tostring(current_gummi_select)
+    map_update_file_path = client_communication_path .. "mapupdate" .. "_" .. tostring(map_update_date) .. "_" .. world_id .. "_" .. room_id
+    if not file_exists(map_update_file_path) then
+        file = io.open(map_update_file_path, "w")
+        io.output(file)
+        io.write("")
+        io.close(file)
+    end
+end
+
+local canExecute = false
+
+function _OnInit()
+    IsEpicGLVersion  = 0x3A2B86
+    IsSteamGLVersion = 0x3A29A6
+    if GAME_ID == 0xAF71841E and ENGINE_TYPE == "BACKEND" then
+        if ReadByte(IsEpicGLVersion) == 0xF0 then
+            ConsolePrint("Epic Version Detected")
+            game_version = 1
+            canExecute = true
+        end
+        if ReadByte(IsSteamGLVersion) == 0xF0 then
+            ConsolePrint("Steam Version Detected")
+            game_version = 2
+            canExecute = true
+        end
+    end
+end
+
+local WORLD_ID_OVERVIEW = 0
+local WORLD_ID_AGRABAH = 8
+
+-- Initialize world state.
+local update_world = 0
+local last_seen_world = 0
+local last_seen_room = 0
+local gummi_select = 255
+
+function _OnFrame()
+    if canExecute then
+        local is_update = false
+        if is_in_gummi_ship() then
+            if update_world ~= WORLD_ID_OVERVIEW then
+                -- Boarded gummi ship. Update map to Overworld.
+                update_world = WORLD_ID_OVERVIEW
+                last_seen_room = 0
+                is_update = true
+            end
+        else
+            if last_seen_world ~= read_world() then
+                -- Current world changed. Update map to new world unless gummi select already updated.
+                last_seen_world = read_world()
+                if update_world ~= last_seen_world then
+                    update_world = last_seen_world
+                    is_update = true
+                end
+            elseif gummi_select ~= read_gummi_select() then
+                -- Gummi travel selected for new world. Update map to new world.
+                gummi_select = read_gummi_select()
+                update_world = gummi_select
+                is_update = true
+            elseif last_seen_world ~= update_world then
+                -- No longer in gummi ship. Returned to previous world.
+                update_world = last_seen_world
+                is_update = true
+            end
+            if update_world == WORLD_ID_AGRABAH and last_seen_room ~= read_room() then
+                -- Update map for a room change in Agrabah due to Cave of Wonders.
+                last_seen_room = read_room()
+                is_update = true
+            end
+        end
+
+        if is_update then
+            write_map_update_file(update_world, last_seen_room)
+        end
+    end
+end

--- a/Static Files/scripts/1fmRandoMapUpdate.lua
+++ b/Static Files/scripts/1fmRandoMapUpdate.lua
@@ -2,9 +2,15 @@ LUAGUI_NAME = "1fmRandoMapUpdate"
 LUAGUI_AUTH = "culk"
 LUAGUI_DESC = "Kingdom Hearts 1FM Randomizer Update Tracker Map Tab"
 
--- TODO: test if can use global util functions
+game_version = 1
+frame_count = 0
+local canExecute = false
 
-local game_version = 1
+-- World state.
+local update_world = 0
+local last_seen_world = 0
+local last_seen_room = 0
+local gummi_select = 255
 
 if os.getenv('LOCALAPPDATA') ~= nil then
     client_communication_path = os.getenv('LOCALAPPDATA') .. "\\KH1FM\\"
@@ -22,20 +28,18 @@ function file_exists(name)
 end
 
 function read_world()
-    --[[Gets the numeric value of the currently occupied world]]
     local world_address = {0x2340E5C, 0x233FE84}
     return ReadByte(world_address[game_version])
 end
 
 function read_room()
-    --[[Gets the numeric value of the currently occupied room]]
     local room_address = {0x2340E5C + 0x68, 0x233FE84 + 0x8}
     return ReadByte(room_address[game_version])
 end
 
 function is_in_gummi_ship()
     local inGummi = {0x50832D, 0x5075A8}
-    return ReadByte(inGummi[game_version]) ~= 0
+    return ReadInt(inGummi[game_version]) > 0
 end
 
 function read_gummi_select()
@@ -45,7 +49,6 @@ end
 
 function write_map_update_file(world_id, room_id)
     map_update_date = os.date("!%Y%m%d%H%M%S")
-    --map_update_file_path = client_communication_path .. "mapupdate" .. "_" .. tostring(map_update_date) .. "_" .. tostring(world_id) .. "_" .. tostring(room_id) .. "_" .. tostring(current_gummi) .. "_" .. tostring(current_gummi_select)
     map_update_file_path = client_communication_path .. "mapupdate" .. "_" .. tostring(map_update_date) .. "_" .. world_id .. "_" .. room_id
     if not file_exists(map_update_file_path) then
         file = io.open(map_update_file_path, "w")
@@ -55,7 +58,50 @@ function write_map_update_file(world_id, room_id)
     end
 end
 
-local canExecute = false
+function main()
+    local is_update = false
+
+    if is_in_gummi_ship() then
+        if update_world ~= 0 then
+            -- Boarded gummi ship. Update map to Overworld.
+            update_world = 0
+            is_update = true
+        end
+    else
+        if last_seen_world ~= read_world() then
+            -- Current world changed. Update map to new world unless gummi select menu already updated it.
+            last_seen_world = read_world()
+            if update_world ~= last_seen_world then
+                update_world = last_seen_world
+                is_update = true
+            end
+        elseif gummi_select ~= read_gummi_select() then
+            -- Gummi travel selected for new world. Update map to new world.
+            gummi_select = read_gummi_select()
+            update_world = gummi_select
+            is_update = true
+        elseif gummi_select ~= update_world and last_seen_world ~= update_world then
+            -- No longer in gummi ship, but world hasn't changed. Returned to previous world.
+            if (last_seen_world == 1 and gummi_select == 3) then
+                -- Returning to Destiny Islands selected from Traverse Town.
+                update_world = last_seen_world
+            else
+                update_world = gummi_select
+            end
+            is_update = true
+        end
+
+        if update_world == 8 and last_seen_room ~= read_room() then
+            -- Update map for a room change in Agrabah due to Cave of Wonders.
+            last_seen_room = read_room()
+            is_update = true
+        end
+    end
+
+    if is_update then
+        write_map_update_file(update_world, last_seen_room)
+    end
+end
 
 function _OnInit()
     IsEpicGLVersion  = 0x3A2B86
@@ -74,52 +120,9 @@ function _OnInit()
     end
 end
 
-local WORLD_ID_OVERVIEW = 0
-local WORLD_ID_AGRABAH = 8
-
--- Initialize world state.
-local update_world = 0
-local last_seen_world = 0
-local last_seen_room = 0
-local gummi_select = 255
-
 function _OnFrame()
-    if canExecute then
-        local is_update = false
-        if is_in_gummi_ship() then
-            if update_world ~= WORLD_ID_OVERVIEW then
-                -- Boarded gummi ship. Update map to Overworld.
-                update_world = WORLD_ID_OVERVIEW
-                last_seen_room = 0
-                is_update = true
-            end
-        else
-            if last_seen_world ~= read_world() then
-                -- Current world changed. Update map to new world unless gummi select already updated.
-                last_seen_world = read_world()
-                if update_world ~= last_seen_world then
-                    update_world = last_seen_world
-                    is_update = true
-                end
-            elseif gummi_select ~= read_gummi_select() then
-                -- Gummi travel selected for new world. Update map to new world.
-                gummi_select = read_gummi_select()
-                update_world = gummi_select
-                is_update = true
-            elseif last_seen_world ~= update_world then
-                -- No longer in gummi ship. Returned to previous world.
-                update_world = last_seen_world
-                is_update = true
-            end
-            if update_world == WORLD_ID_AGRABAH and last_seen_room ~= read_room() then
-                -- Update map for a room change in Agrabah due to Cave of Wonders.
-                last_seen_room = read_room()
-                is_update = true
-            end
-        end
-
-        if is_update then
-            write_map_update_file(update_world, last_seen_room)
-        end
+    if canExecute and frame_count == 0 then
+        main()
     end
+    frame_count = (frame_count + 1) % 30
 end


### PR DESCRIPTION
Sends the player's current world and room ID to the AP client by creating a "mapupdate" file in the game communication path. A new "mapupdate" is sent whenever the player enters the gummi ship or moves to a new world. The specific events that will cause a map update are:

- Player enters the gummi ship from a save point or backs out of the gummi world select menu: sets map to "0" for the "Overworld"
- Player selects a world to travel to from their gummi ship, before selecting a spawn point: sets the map to the world ID of the selected world such as "Traverse Town"
- Player moves to a new world either from the gummi selection window or via a cutscene warp: sets the map to the new world ID
- Player moves to a new room in Agrabah: sets the map to "Agrabah" or "Cave of Wonders" depending on the new room ID (Agrabah is the only world that has two different tabs in the PopTracker)

Tested only on the Steam version of KH1FM, but the memory addresses used are also used by other scripts in the rando mod. During testing I did not notice any instances of incorrect map information being communicated such as stuttering between maps or sending the wrong map information.

mapupdate files in the game communication path take the form of `mapupdate_{timestamp}_{world_id}_{room_id}`. During testing, approximately 150 of these files were created during a 3 hr game with all extra worlds turned off. These files are cleaned up between play sessions.

In order for this information to reach the tracker they will have to be read by the AP client and sent as Bounce packets.